### PR TITLE
More robust PostgreSQL version detection

### DIFF
--- a/modules/postgresql/sources.mk
+++ b/modules/postgresql/sources.mk
@@ -20,8 +20,8 @@ else
 pg_config ?= pg_config
 endif
 
-postgresql_major = $(shell $(pg_config) --version | sed -e "s/PostgreSQL \\([0-9]*\\)\\.\\([0-9]*\\)\\.\\([0-9]*\\)/\\1/")
-postgresql_minor = $(shell $(pg_config) --version | sed -e "s/PostgreSQL \\([0-9]*\\)\\.\\([0-9]*\\)\\.\\([0-9]*\\)/\\2/")
+postgresql_major = $(shell $(pg_config) --version | sed -e "s/PostgreSQL \\([0-9]*\\)\\.\\([0-9]*\\).*/\\1/")
+postgresql_minor = $(shell $(pg_config) --version | sed -e "s/PostgreSQL \\([0-9]*\\)\\.\\([0-9]*\\).*/\\2/")
 
 common_sources += modules/postgresql/Connection.cc \
                   modules/postgresql/Statement.cc \


### PR DESCRIPTION
The version check only worked with pg_config reporting 3-component
version number *and* no extra information. This does not work with libpq
as available in Ubuntu repositories, which both (a) only reports major
and minor version components, and (b) adds more information in the
parens afterwards.

But only major and minor are actually used, so just read those in and
slurp the rest of the line.

Fixes #4.